### PR TITLE
use readlink to cd to the script directory

### DIFF
--- a/user.sh
+++ b/user.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd `dirname ${BASH_SOURCE[0]}`
+cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 . wg.def
 CLIENT_TPL_FILE=client.conf.tpl


### PR DESCRIPTION
use readlink to cd to the script direction, to support symbolic link to e.g. /user/bin etc.